### PR TITLE
final-openstack-v2

### DIFF
--- a/hello-world-example/openstack.yaml
+++ b/hello-world-example/openstack.yaml
@@ -2,7 +2,7 @@ tosca_definitions_version: cloudify_dsl_1_3
 
 imports:
   - http://cloudify.co/spec/cloudify/4.5.5/types.yaml
-  - plugin:cloudify-openstack-plugin
+  - plugin:cloudify-openstack-plugin?version=2.14.7
   - install-script.yaml
 
 inputs:

--- a/open-source-vnf/connected-host/openstack.yaml
+++ b/open-source-vnf/connected-host/openstack.yaml
@@ -17,7 +17,7 @@ dsl_definitions:
 imports:
 
   - http://cloudify.co/spec/cloudify/4.5.5/types.yaml
-  - plugin:cloudify-openstack-plugin
+  - plugin:cloudify-openstack-plugin?version=2.14.7
 
 inputs:
 

--- a/open-source-vnf/network-topology/openstack.yaml
+++ b/open-source-vnf/network-topology/openstack.yaml
@@ -17,7 +17,7 @@ dsl_definitions:
 imports:
 
   - http://cloudify.co/spec/cloudify/4.5.5/types.yaml
-  - plugin:cloudify-openstack-plugin
+  - plugin:cloudify-openstack-plugin?version=2.14.7
 
 inputs:
 

--- a/openstack-example-network/blueprint.yaml
+++ b/openstack-example-network/blueprint.yaml
@@ -4,7 +4,7 @@ description: A simple GCP example network.
 
 imports:
   - http://cloudify.co/spec/cloudify/4.5.5/types.yaml
-  - plugin:cloudify-openstack-plugin
+  - plugin:cloudify-openstack-plugin?version=2.14.7
 
 inputs:
 


### PR DESCRIPTION
This is the last release that will use Openstack V2. After this I will update all examples to use Openstack v3. So this release includes a hard import on Openstack Plugin v2.14.7.