### PR TITLE
Fixed "Invalid value for port 0" issue

### DIFF
--- a/kubernetes/openstack.yaml
+++ b/kubernetes/openstack.yaml
@@ -142,11 +142,11 @@ node_templates:
       security_group_rules:
         - direction: ingress
           protocol: tcp
-          port_range_min: 0
+          port_range_min: 1
           port_range_max: 65535
         - direction: ingress
           protocol: udp
-          port_range_min: 0
+          port_range_min: 1
           port_range_max: 65535
         - direction: ingress
           protocol: icmp


### PR DESCRIPTION
This merge request will close this issue:
https://github.com/cloudify-community/blueprint-examples/issues/82

My Openstack says that "port_range_min" cannot be 0.