### PR TITLE
Cy 2454 support gcp credentials config as one big json string

### DIFF
--- a/db-lb-app/README.md
+++ b/db-lb-app/README.md
@@ -14,7 +14,7 @@ The components are:
   - Plugins:
     - `cloudify-aws-plugin`
     - `cloudify-azure-plugin`
-    - `cloudify-gcp-plugin`
+    - `cloudify-gcp-plugin version 1.6.0 or higher `
     - `cloudify-openstack-plugin v3`
     - `cloudify-utilites-plugin`
     - `cloudify-ansible-plugin`
@@ -35,12 +35,7 @@ The components are:
       - `azure_client_secret`: Azure subscription ID: `cfy secrets create -u azure_client_secret -s ...........`.
       - `azure_location`: Azure subscription ID: `cfy secrets create -u azure_location -s westeurope`.
     - GCP:
-      - `gcp_client_x509_cert_url`: A GCP Service Account Client Cert URL: `cfy secrets create gcp_client_x509_cert_url -s client_cert_url`
-      - `gcp_client_email`: A GCP Service Account client email: `cfy secrets create gcp_client_email -s client_email`
-      - `gcp_client_id`: A GCP Service Account Client ID: `cfy secrets create gcp_client_id -s client_id`
-      - `gcp_project_id`: A GCP Project ID: `cfy secrets create gcp_project_id -s project_id`
-      - `gcp_private_key_id`: A GCP Project Private Key ID: `cfy secrets create gcp_private_key_id -s private_key_id`
-      - `gcp_private_key`: A GCP project Private Key: `cfy secrets create gcp_private_key -f ./path/to/private-key`.
+      - `gcp_credentials`: A GCP service account key in JSON format. **Hint: Create this secret from a file:** `cfy secrets create gcp_credentials -f ./path/to/JSON key`.
       - `gcp_region`: A GCP Region such as `us-east1`: `cfy secrets create gcp_region -s private_key_id`
       - `gcp_zone`: A GCP Zone such as `us-east1-b`: `cfy secrets create gcp_zone -s zone`
     - Openstack:

--- a/db-lb-app/infrastructure/gcp.yaml
+++ b/db-lb-app/infrastructure/gcp.yaml
@@ -29,18 +29,7 @@ inputs:
 dsl_definitions:
 
   client_config: &gcp_config
-    auth:
-      type: service_account
-      auth_uri: https://accounts.google.com/o/oauth2/auth
-      token_uri: https://accounts.google.com/o/oauth2/token
-      auth_provider_x509_cert_url: https://www.googleapis.com/oauth2/v1/certs
-      client_x509_cert_url: { get_secret: gcp_client_x509_cert_url }
-      client_email: { get_secret: gcp_client_email }
-      client_id: { get_secret: gcp_client_id }
-      project_id: { get_secret: gcp_project_id }
-      private_key_id: { get_secret: gcp_private_key_id }
-      private_key: { get_secret: gcp_private_key }
-    project: { get_secret: gcp_project_id }
+    auth: { get_secret: gcp_credentials }
     zone: { get_secret: gcp_zone }
 
 node_templates:

--- a/db-lb-app/infrastructure/gcp.yaml
+++ b/db-lb-app/infrastructure/gcp.yaml
@@ -2,7 +2,7 @@ tosca_definitions_version: cloudify_dsl_1_3
 
 imports:
   - http://cloudify.co/spec/cloudify/5.0.5/types.yaml
-  - plugin:cloudify-gcp-plugin
+  - plugin:cloudify-gcp-plugin?version= >=1.6.0
   - plugin:cloudify-utilities-plugin
   - includes/cloud-init.yaml
 
@@ -26,11 +26,21 @@ inputs:
       The username of the agent running on the instance created from the image.
     default: 'centos'
 
+  region:
+    type: string
+    description: The GCP region to deploy the application in, such as europe-west1.
+    default: { get_secret: gcp_region }
+
+  zone:
+    type: string
+    description: The GCP zone to deploy the application in, such as europe-west1-b.
+    default: { get_secret: gcp_zone }
+
 dsl_definitions:
 
   client_config: &gcp_config
     auth: { get_secret: gcp_credentials }
-    zone: { get_secret: gcp_zone }
+    zone: { get_input: zone }
 
 node_templates:
 

--- a/gcp-example-network/README.md
+++ b/gcp-example-network/README.md
@@ -22,11 +22,6 @@ Upload the required plugins:
 
 If you do not provide your own `deployment inputs` below, you must add these secrets to your Cloudify Manager `tenant`:
 
-  * `gcp_client_x509_cert_url`: A GCP Service Account Client Cert URL.
-  * `gcp_client_email`: A GCP Service Account client email.
-  * `gcp_client_id`: A GCP Service Account Client ID.
-  * `gcp_project_id`: A GCP Project ID.
-  * `gcp_private_key_id`: A GCP Project Private Key ID.
-  * `gcp_private_key`: A GCP project Private Key. **Hint: Create this secret from a file:** `cfy secrets create private_key -f ./path/to/private-key`.
+  * `gcp_credentials`: A GCP service account key in JSON format. **Hint: Create this secret from a file:** `cfy secrets create gcp_credentials -f ./path/to/JSON key`.
   * `gcp_region`: A GCP Region such as `us-east1`.
   * `gcp_zone`: A GCP Zone such as `us-east1-b`.

--- a/gcp-example-network/blueprint.yaml
+++ b/gcp-example-network/blueprint.yaml
@@ -7,30 +7,9 @@ imports:
   - plugin:cloudify-gcp-plugin
 
 inputs:
-
-  client_x509_cert_url:
+  gcp_crdentials:
     type: string
-    default: { get_secret: gcp_client_x509_cert_url }
-
-  client_email:
-    type: string
-    default: { get_secret: gcp_client_email }
-
-  client_id:
-    type: string
-    default: { get_secret: gcp_client_id }
-
-  project_id:
-    type: string
-    default: { get_secret: gcp_project_id }
-
-  private_key_id:
-    type: string
-    default: { get_secret: gcp_private_key_id }
-
-  private_key:
-    type: string
-    default: { get_secret: gcp_private_key }
+    default: { get_secret: gcp_credentials }
 
   zone:
     default: { get_secret: gcp_zone }
@@ -50,19 +29,8 @@ inputs:
 dsl_definitions:
 
   client_config: &client_config
-    auth:
-      type: service_account
-      auth_uri: https://accounts.google.com/o/oauth2/auth
-      token_uri: https://accounts.google.com/o/oauth2/token
-      auth_provider_x509_cert_url: https://www.googleapis.com/oauth2/v1/certs
-      client_x509_cert_url: { get_input: client_x509_cert_url }
-      client_email: { get_input: client_email }
-      client_id: { get_input: client_id }
-      project_id: { get_input: project_id }
-      private_key_id: { get_input: private_key_id }
-      private_key: { get_input: private_key }
-    project: { get_input: project_id }
-    zone: { get_input: zone }
+    auth: { get_secret: gcp_credentials }
+    zone: { get_secret: gcp_zone }
 
 node_templates:
 

--- a/gcp-example-network/blueprint.yaml
+++ b/gcp-example-network/blueprint.yaml
@@ -4,7 +4,7 @@ description: A simple GCP example network.
 
 imports:
   - http://cloudify.co/spec/cloudify/5.0.5/types.yaml
-  - plugin:cloudify-gcp-plugin
+  - plugin:cloudify-gcp-plugin?version= >=1.6.0
 
 inputs:
   gcp_crdentials:
@@ -30,7 +30,7 @@ dsl_definitions:
 
   client_config: &client_config
     auth: { get_secret: gcp_credentials }
-    zone: { get_secret: gcp_zone }
+    zone: { get_input: zone }
 
 node_templates:
 

--- a/getting-started/README.md
+++ b/getting-started/README.md
@@ -207,14 +207,7 @@ If you need help locating your credentials, read about [Azure Plugin Configurati
 #### GCP secrets checklist
 
 If you are a GCP user, you must create the following secrets:
-
-  - [ ] `gcp_client_x509_cert_url`: A GCP Service Account Client Cert URL: `cfy secrets create gcp_client_x509_cert_url -s client_cert_url`
-  - [ ] `gcp_client_email`: A GCP Service Account client email: `cfy secrets create gcp_client_email -s client_email`
-  - [ ] `gcp_client_id`: A GCP Service Account Client ID: `cfy secrets create gcp_client_id -s client_id`
-  - [ ] `gcp_project_id`: A GCP Project ID: `cfy secrets create gcp_project_id -s project_id`
-  - [ ] `gcp_private_key_id`: A GCP Project Private Key ID: `cfy secrets create gcp_private_key_id -s private_key_id`
-  - [ ] `gcp_private_key`: A GCP project Private Key: `cfy secrets create gcp_private_key -f ./path/to/private-key`.
-  - [ ] `gcp_region`: A GCP Region such as `us-east1`: `cfy secrets create gcp_region -s private_key_id`
+  - [ ] `gcp_credentials`: A GCP service account key in JSON format. **Hint: Create this secret from a file:** `cfy secrets create gcp_credentials -f ./path/to/JSON key`.
   - [ ] `gcp_zone`: A GCP Zone such as `us-east1-b`: `cfy secrets create gcp_zone -s zone`
 
 If you need help locating your credentials, read about [GCP Plugin Configuration](https://docs.cloudify.co/5.0.0/working_with/official_plugins/infrastructure/gcp/).
@@ -238,3 +231,5 @@ If you are an Openstack user, you must create the following secrets:
 If you need help locating your credentials, read about [Openstack RC File](https://docs.openstack.org/zh_CN/user-guide/common/cli-set-environment-variables-using-openstack-rc.html), although sourcing is not enough, these values must be created as secrets:
 
 [Return to requirements](#requirements).
+
+add command to install the infra+app blueprints 

--- a/getting-started/infra/gcp.yaml
+++ b/getting-started/infra/gcp.yaml
@@ -41,18 +41,7 @@ inputs:
 dsl_definitions:
 
   client_config: &gcp_config
-    auth:
-      type: service_account
-      auth_uri: https://accounts.google.com/o/oauth2/auth
-      token_uri: https://accounts.google.com/o/oauth2/token
-      auth_provider_x509_cert_url: https://www.googleapis.com/oauth2/v1/certs
-      client_x509_cert_url: { get_secret: gcp_client_x509_cert_url }
-      client_email: { get_secret: gcp_client_email }
-      client_id: { get_secret: gcp_client_id }
-      project_id: { get_secret: gcp_project_id }
-      private_key_id: { get_secret: gcp_private_key_id }
-      private_key: { get_secret: gcp_private_key }
-    project: { get_secret: gcp_project_id }
+    auth: { get_secret: gcp_credentials }
     zone: { get_secret: gcp_zone }
 
 node_templates:

--- a/getting-started/infra/gcp.yaml
+++ b/getting-started/infra/gcp.yaml
@@ -2,7 +2,7 @@ tosca_definitions_version: cloudify_dsl_1_3
 
 imports:
   - http://cloudify.co/spec/cloudify/5.0.5/types.yaml
-  - plugin:cloudify-gcp-plugin
+  - plugin:cloudify-gcp-plugin?version= >=1.6.0
   - plugin:cloudify-utilities-plugin
 
 
@@ -12,6 +12,11 @@ inputs:
     type: string
     description: The GCP region to deploy the application in, such as europe-west1.
     default: 'europe-west1'
+
+  zone:
+    type: string
+    description: The GCP zone to deploy the application in, such as europe-west1-b.
+    default: 'europe-west1-b'
 
   network_name:
     type: string
@@ -42,7 +47,7 @@ dsl_definitions:
 
   client_config: &gcp_config
     auth: { get_secret: gcp_credentials }
-    zone: { get_secret: gcp_zone }
+    zone: { get_input: zone }
 
 node_templates:
 
@@ -57,7 +62,7 @@ node_templates:
       use_public_ip: true
       image_id: { get_input: image }
       instance_type: { get_input: instance_type }
-      zone: { get_secret: gcp_zone }
+      zone: { get_input: zone }
       external_ip: true
     relationships:
     - type: cloudify.relationships.depends_on

--- a/hello-world-example/README.md
+++ b/hello-world-example/README.md
@@ -50,11 +50,15 @@ cfy secrets create azure_client_secret --secret-string <value>
 ```
 
 For **GCP**
-```shell
-gcp_credentials: A GCP service account key in JSON format. Hint: Create this secret from a file:
+
+gcp_credentials: A GCP service account key in JSON format. **Hint: Create this secret from a file:**
+```shell   
 `cfy secrets create gcp_credentials -f ./path/to/JSON key`.
-gcp_zone: A GCP Zone such as `us-east1-b`: 
-`cfy secrets create gcp_zone --secret-string <zone>`
+```                                             
+gcp_zone: A GCP Zone such as `us-east1-b`:                                                              
+
+```shell
+cfy secrets create gcp_zone --secret-string <zone>                                                                                                                                              
 ```
 
 For **Openstack**

--- a/hello-world-example/README.md
+++ b/hello-world-example/README.md
@@ -51,14 +51,10 @@ cfy secrets create azure_client_secret --secret-string <value>
 
 For **GCP**
 ```shell
-cfy secrets create gcp_client_x509_cert_url --secret-string <value>
-cfy secrets create gcp_client_email --secret-string <value>
-cfy secrets create gcp_client_id --secret-string <value>
-cfy secrets create gcp_project_id --secret-string <value>
-cfy secrets create gcp_private_key_id --secret-string <value>
-cfy secrets create gcp_private_key --secret-string <value>
-cfy secrets create gcp_project_id --secret-string <value>
-cfy secrets create gcp_zone --secret-string <value>
+gcp_credentials: A GCP service account key in JSON format. Hint: Create this secret from a file:
+`cfy secrets create gcp_credentials -f ./path/to/JSON key`.
+gcp_zone: A GCP Zone such as `us-east1-b`: 
+`cfy secrets create gcp_zone --secret-string <zone>`
 ```
 
 For **Openstack**

--- a/hello-world-example/README.md
+++ b/hello-world-example/README.md
@@ -15,6 +15,7 @@ This document will guide you how to run the examples step by step.
 Download the example
 ```shell
 curl -L https://github.com/cloudify-cosmo/cloudify-hello-world-example/archive/master.zip -o cloudify-hello-world-example.zip
+i think its the wrong link!! fix that 
 ```
 
 Extract the example
@@ -87,7 +88,7 @@ cfy install azure.yaml -i location=eastus -i agent_password=OpenS3sVm3
 For **GCP**:
 
 ```shell
-cfy install gcp.yaml region=europe-west1
+cfy install gcp.yaml -i region=<region>
 ```
 
 For **Openstack**:
@@ -109,8 +110,14 @@ cfy install openstack.yaml \
      -i image=e41430f7-9131-495b-927f-e7dc4b8994c8 \
      -i flavor=2
 ```
-
-
+###Get deployment id:       
+```shell
+cfy deployments list         
+```
+###Get the URL of the webserver
+```shell
+cfy deployment outputs <deployment_id>
+```
 ## Using the Web UI
 
 ### Open the Web UI

--- a/hello-world-example/gcp.yaml
+++ b/hello-world-example/gcp.yaml
@@ -41,19 +41,9 @@ inputs:
 dsl_definitions:
 
   client_config: &gcp_config
-    auth:
-      type: service_account
-      auth_uri: https://accounts.google.com/o/oauth2/auth
-      token_uri: https://accounts.google.com/o/oauth2/token
-      auth_provider_x509_cert_url: https://www.googleapis.com/oauth2/v1/certs
-      client_x509_cert_url: { get_secret: gcp_client_x509_cert_url }
-      client_email: { get_secret: gcp_client_email }
-      client_id: { get_secret: gcp_client_id }
-      project_id: { get_secret: gcp_project_id }
-      private_key_id: { get_secret: gcp_private_key_id }
-      private_key: { get_secret: gcp_private_key }
-    project: { get_secret: gcp_project_id }
+    auth: { get_secret: gcp_credentials }
     zone: { get_secret: gcp_zone }
+
 
 node_templates:
 

--- a/hello-world-example/gcp.yaml
+++ b/hello-world-example/gcp.yaml
@@ -2,7 +2,7 @@ tosca_definitions_version: cloudify_dsl_1_3
 
 imports:
   - http://cloudify.co/spec/cloudify/5.0.5/types.yaml
-  - plugin:cloudify-gcp-plugin
+  - plugin:cloudify-gcp-plugin?version= >=1.6.0
   - plugin:cloudify-ansible-plugin
   - plugin:cloudify-utilities-plugin
   - includes/ansible.yaml
@@ -12,6 +12,12 @@ inputs:
   region:
     type: string
     description: The GCP region to deploy the application in, such as europe-west1.
+    default: 'europe-west1'
+
+  zone:
+    type: string
+    description: The GCP zone to deploy the application in, such as europe-west1-b.
+    default: 'europe-west1-b'
 
   network_name:
     type: string
@@ -42,7 +48,7 @@ dsl_definitions:
 
   client_config: &gcp_config
     auth: { get_secret: gcp_credentials }
-    zone: { get_secret: gcp_zone }
+    zone: { get_input: zone }
 
 
 node_templates:
@@ -58,7 +64,7 @@ node_templates:
       use_public_ip: true
       image_id: { get_input: image }
       instance_type: { get_input: instance_type }
-      zone: { get_secret: gcp_zone }
+      zone: { get_input: zone }
       external_ip: true
     relationships:
     - type: cloudify.relationships.depends_on

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -35,15 +35,15 @@ cfy secrets create azure_client_secret --secret-string <value>
 ```
 
 For **GCP**
+
+gcp_credentials: A GCP service account key in JSON format. **Hint: Create this secret from a file:**
+```shell   
+`cfy secrets create gcp_credentials -f ./path/to/JSON key`.
+```                                             
+gcp_zone: A GCP Zone such as `us-east1-b`:                                                              
+
 ```shell
-cfy secrets create gcp_client_x509_cert_url --secret-string <value>
-cfy secrets create gcp_client_email --secret-string <value>
-cfy secrets create gcp_client_id --secret-string <value>
-cfy secrets create gcp_project_id --secret-string <value>
-cfy secrets create gcp_private_key_id --secret-string <value>
-cfy secrets create gcp_private_key --secret-string <value>
-cfy secrets create gcp_project_id --secret-string <value>
-cfy secrets create gcp_zone --secret-string <value>
+cfy secrets create gcp_zone --secret-string <zone>                                                                                                                                              
 ```
 
 For **Openstack**
@@ -75,6 +75,12 @@ For **Azure**:
 
 ```shell
 cfy install azure.yaml -i location=westeurope
+```
+
+For **GCP**:
+
+```shell
+cfy install gcp.yaml -i region=<region>
 ```
 
 For **Openstack**:

--- a/kubernetes/gcp.yaml
+++ b/kubernetes/gcp.yaml
@@ -2,7 +2,7 @@ tosca_definitions_version: cloudify_dsl_1_3
 
 imports:
   - http://cloudify.co/spec/cloudify/5.0.5/types.yaml
-  - plugin:cloudify-gcp-plugin
+  - plugin:cloudify-gcp-plugin?version= >=1.6.0
   - plugin:cloudify-ansible-plugin
   - plugin:cloudify-utilities-plugin
   - includes/application.yaml
@@ -14,6 +14,11 @@ inputs:
     type: string
     description: The GCP region to deploy the application in, such as europe-west1.
     default: { get_secret: gcp_region }
+
+  zone:
+    type: string
+    description: The GCP zone to deploy the application in, such as europe-west1-b.
+    default: { get_secret: gcp_zone }
 
   network_name:
     type: string
@@ -43,7 +48,7 @@ dsl_definitions:
 
   client_config: &gcp_config
     auth: { get_secret: gcp_credentials }
-    zone: { get_secret: gcp_zone }
+    zone: { get_input: zone }
 
 node_types:
 
@@ -64,7 +69,7 @@ node_types:
       instance_type:
         default: { get_input: instance_type }
       zone:
-        default: { get_secret: gcp_zone }
+        default: { get_input: zone }
       external_ip:
         default: true
       startup_script:

--- a/kubernetes/gcp.yaml
+++ b/kubernetes/gcp.yaml
@@ -42,18 +42,7 @@ inputs:
 dsl_definitions:
 
   client_config: &gcp_config
-    auth:
-      type: service_account
-      auth_uri: https://accounts.google.com/o/oauth2/auth
-      token_uri: https://accounts.google.com/o/oauth2/token
-      auth_provider_x509_cert_url: https://www.googleapis.com/oauth2/v1/certs
-      client_x509_cert_url: { get_secret: gcp_client_x509_cert_url }
-      client_email: { get_secret: gcp_client_email }
-      client_id: { get_secret: gcp_client_id }
-      project_id: { get_secret: gcp_project_id }
-      private_key_id: { get_secret: gcp_private_key_id }
-      private_key: { get_secret: gcp_private_key }
-    project: { get_secret: gcp_project_id }
+    auth: { get_secret: gcp_credentials }
     zone: { get_secret: gcp_zone }
 
 node_types:

--- a/prometheus/README.md
+++ b/prometheus/README.md
@@ -36,15 +36,21 @@ cfy secrets create azure_client_secret --secret-string <value>
 ```
 
 For **GCP**
+
+gcp_credentials: A GCP service account key in JSON format. **Hint: Create this secret from a file:**
+```shell   
+`cfy secrets create gcp_credentials -f ./path/to/JSON key`.
+```  
+                                           
+gcp_zone: A GCP Zone such as `us-east1-b`:                                                              
+
 ```shell
-cfy secrets create gcp_client_x509_cert_url --secret-string <value>
-cfy secrets create gcp_client_email --secret-string <value>
-cfy secrets create gcp_client_id --secret-string <value>
-cfy secrets create gcp_project_id --secret-string <value>
-cfy secrets create gcp_private_key_id --secret-string <value>
-cfy secrets create gcp_private_key --secret-string <value>
-cfy secrets create gcp_project_id --secret-string <value>
-cfy secrets create gcp_zone --secret-string <value>
+cfy secrets create gcp_zone --secret-string <zone>                                                                                                                                              
+```
+
+gcp_project_id:
+```shell
+cfy secrets create gcp_project_id --secret-string <project_id>                                                                                                                                              
 ```
 
 For **Openstack**
@@ -76,6 +82,12 @@ For **Azure**:
 
 ```shell
 cfy install azure.yaml -i location=westeurope
+```
+
+For **GCP**:
+
+```shell
+cfy install gcp.yaml -i region=<region>
 ```
 
 For **Openstack**:

--- a/prometheus/gcp.yaml
+++ b/prometheus/gcp.yaml
@@ -2,7 +2,7 @@ tosca_definitions_version: cloudify_dsl_1_3
 
 imports:
   - http://cloudify.co/spec/cloudify/5.0.5/types.yaml
-  - plugin:cloudify-gcp-plugin
+  - plugin:cloudify-gcp-plugin?version= >=1.6.0
   - plugin:cloudify-ansible-plugin
   - includes/application.yaml
 
@@ -11,6 +11,12 @@ inputs:
   region:
     type: string
     description: The GCP region to deploy the application in, such as europe-west1.
+    default: { get_secret: gcp_region }
+
+  zone:
+    type: string
+    description: The GCP zone to deploy the application in, such as europe-west1-b.
+    default: { get_secret: gcp_zone }
 
   network_name:
     type: string
@@ -44,7 +50,7 @@ dsl_definitions:
 
   client_config: &gcp_config
     auth: { get_secret: gcp_credentials }
-    zone: { get_secret: gcp_zone }
+    zone: { get_input: zone }
 
 node_templates:
 
@@ -92,7 +98,7 @@ node_templates:
       use_public_ip: true
       image_id: { get_input: image }
       instance_type: { get_input: instance_type }
-      zone: { get_secret: gcp_zone }
+      zone: { get_input: zone }
       external_ip: true
     interfaces:
       cloudify.interfaces.lifecycle:

--- a/prometheus/gcp.yaml
+++ b/prometheus/gcp.yaml
@@ -43,18 +43,7 @@ inputs:
 dsl_definitions:
 
   client_config: &gcp_config
-    auth:
-      type: service_account
-      auth_uri: https://accounts.google.com/o/oauth2/auth
-      token_uri: https://accounts.google.com/o/oauth2/token
-      auth_provider_x509_cert_url: https://www.googleapis.com/oauth2/v1/certs
-      client_x509_cert_url: { get_secret: gcp_client_x509_cert_url }
-      client_email: { get_secret: gcp_client_email }
-      client_id: { get_secret: gcp_client_id }
-      project_id: { get_secret: gcp_project_id }
-      private_key_id: { get_secret: gcp_private_key_id }
-      private_key: { get_secret: gcp_private_key }
-    project: { get_secret: gcp_project_id }
+    auth: { get_secret: gcp_credentials }
     zone: { get_secret: gcp_zone }
 
 node_templates:


### PR DESCRIPTION
update the blueprints examples on gcp infrastructure to receive the service account credentials in JSON format. still need to fix some documentation. 