### PR TITLE
RD-278-Fix-AKS-Node-Public-IP

### DIFF
--- a/kubernetes/azure-aks/blueprint.yaml
+++ b/kubernetes/azure-aks/blueprint.yaml
@@ -85,7 +85,7 @@ dsl_definitions:
           - "1"
           - "2"
           - "3"
-        enableNodePublicIP: true
+        # enableNodePublicIP: true
         mode: "System"
     linux_profile:
       adminUsername: "azureuser"


### PR DESCRIPTION
removing enableNodePublicIP from Azure-AKS blueprint example , because on latest Azure plugin it started to give
Node public IP is not allowed since feature 'Microsoft.ContainerService/NodePublicIPPreview' is not enabled
and based on the preview it seems the feature is still under development 
https://github.com/Azure/AKS/issues/983#issuecomment-693520416

