### PR TITLE
Pin NodeJS version to 17 for CentOS 7 support

### DIFF
--- a/getting-started/scripts/nodejs/install.sh
+++ b/getting-started/scripts/nodejs/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 sudo rm -rf /etc/yum.repos.d/google-cloud.repo
 sudo yum update -y
-curl -fsSL https://rpm.nodesource.com/setup_current.x | sudo bash -
+curl -fsSL https://rpm.nodesource.com/setup_17.x | sudo bash -
 
 sudo setenforce 0
 cat << EOF | sudo tee /etc/selinux/config


### PR DESCRIPTION
This blueprint currently uses one of our infrastructure based VM blueprints, which use CentOS 7. The current version (v18) of NodeJS distributed by NodeSource does not appear to support CentOS 7. The deployment fails due to the error below during install of the `nodejs` package.

I propose here pinning the NodeJS version to a known working version (v17). While we could update the VM images used across all the child BPs, it's unclear how much that would impact (e.g., other BPs may be using those as bases and may be relying on them using CentOS 7).

I spot checked this by running the AWS and AWS-Terraform versions of this deployment.

Install error:
```
Resolving Dependencies
--> Running transaction check
---> Package nodejs.x86_64 2:18.0.0-1nodesource will be installed
--> Processing Dependency: libstdc++.so.6(GLIBCXX_3.4.21)(64bit) for package: 2:nodejs-18.0.0-1nodesource.x86_64
--> Processing Dependency: libc.so.6(GLIBC_2.28)(64bit) for package: 2:nodejs-18.0.0-1nodesource.x86_64
--> Processing Dependency: libm.so.6(GLIBC_2.27)(64bit) for package: 2:nodejs-18.0.0-1nodesource.x86_64
--> Processing Dependency: libstdc++.so.6(CXXABI_1.3.9)(64bit) for package: 2:nodejs-18.0.0-1nodesource.x86_64
--> Processing Dependency: libstdc++.so.6(GLIBCXX_3.4.20)(64bit) for package: 2:nodejs-18.0.0-1nodesource.x86_64
--> Finished Dependency Resolution
Error: Package: 2:nodejs-18.0.0-1nodesource.x86_64 (nodesource)
           Requires: libc.so.6(GLIBC_2.28)(64bit)
Error: Package: 2:nodejs-18.0.0-1nodesource.x86_64 (nodesource)
           Requires: libstdc++.so.6(CXXABI_1.3.9)(64bit)
Error: Package: 2:nodejs-18.0.0-1nodesource.x86_64 (nodesource)
           Requires: libstdc++.so.6(GLIBCXX_3.4.21)(64bit)
Error: Package: 2:nodejs-18.0.0-1nodesource.x86_64 (nodesource)
           Requires: libstdc++.so.6(GLIBCXX_3.4.20)(64bit)
Error: Package: 2:nodejs-18.0.0-1nodesource.x86_64 (nodesource)
           Requires: libm.so.6(GLIBC_2.27)(64bit)
 You could try using --skip-broken to work around the problem
 You could try running: rpm -Va --nofiles --nodigest
```